### PR TITLE
Upgrade actions/checkout, actions/setup-java and actions/cache to latest

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,6 +19,7 @@ jobs:
       uses: actions/setup-java@v5.2.0
       with:
         java-version: 11
+        distribution: temurin
     - name: Cache Maven Dependencies (~/.m2/repository)
       uses: actions/cache@v5.0.3
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2.3.3
+    - uses: actions/checkout@v6.0.2
     - name: Set up JDK 11
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v5.2.0
       with:
         java-version: 11
     - name: Cache Maven Dependencies (~/.m2/repository)
-      uses: actions/cache@v2.1.2
+      uses: actions/cache@v5.0.3
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
- Upgrade actions/checkout to 6.0.2
- Upgrade actions/setup-java to 5.2.0
- Upgrade actions/cache to 5.0.3